### PR TITLE
fix: add content to empty about page

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -10,11 +10,27 @@ export default async function AboutPage() {
         <h1 className="text-xl font-semibold leading-6 text-gray-900 dark:text-white pb-4">
           About
         </h1>
-        <div className="text-gray-500 dark:text-gray-400">
-          <p className="py-1">
-            {/* Add about content here */}
+        <div className="text-gray-700 dark:text-gray-300 space-y-4">
+          <p>
+            Full-stack software engineer based in Houston, TX with experience
+            architecting, deploying, and supporting technical solutions at
+            scale. I specialize in building web applications and APIs using
+            modern technologies including TypeScript, React, Next.js, Node.js,
+            GraphQL, and Kubernetes.
           </p>
-          <p className="py-4">
+          <p>
+            Throughout my career, I&apos;ve worked on enterprise-scale platforms
+            handling billions in annual transactions, developed VR training
+            simulators, and built healthcare technology solutions. I&apos;m
+            passionate about automation, quality assurance, and cloud
+            infrastructure.
+          </p>
+          <p>
+            I&apos;ve spoken at PyCon India and various community meetups,
+            sharing knowledge about bridging frontend and backend technologies
+            using GraphQL.
+          </p>
+          <p className="pt-2">
             <Link
               href="/resume"
               className="text-blue-600 dark:text-blue-400 hover:underline"


### PR DESCRIPTION
The about page only had a placeholder comment. Added a professional bio
describing experience as a full-stack engineer, key technologies, and
speaking experience at PyCon India.