### PR TITLE
ci: allow db:migrate to fail without blocking deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,10 +51,13 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      # Drizzle migrations against the Turso database. Idempotent, so
-      # we run on every push — cheap, and keeps the migration path warm
-      # in case schema work returns.
+      # Drizzle migrations against the Turso database. The DB is inert
+      # scaffolding today (no live client reads it), so this step is
+      # allowed to fail without blocking the deploy — keeps the wiring
+      # in place for when schema work returns. Re-validate the step
+      # when the DB is revived.
       - name: Run database migrations
+        continue-on-error: true
         env:
           TURSO_DATABASE_URL: ${{ secrets.TURSO_DATABASE_URL }}
           TURSO_AUTH_TOKEN: ${{ secrets.TURSO_AUTH_TOKEN }}


### PR DESCRIPTION
## Summary

The post-merge Deploy run for #82/#83 failed at \`bun run db:migrate\`. The DB still has the legacy Next.js schema (tables exist without drizzle's bookkeeping table), so applying our bundled migrations errors out. Today nothing in the runtime reads the DB — it's pure scaffolding — so a failed migration shouldn't block the worker deploy.

Adds \`continue-on-error: true\` to the migration step. When/if the DB is revived for real, drop the flag and reconcile the schema first.

## Test plan

- [x] Manually ran \`bunx wrangler deploy\` against the worker — confirmed the deploy itself works end-to-end (current version on production: \`e1a8179c-67c0-40b7-b6a4-a8a9f9c7186d\`)
- [ ] After merge, push triggers Deploy → migration step shows red ✗ as a sub-step but the job overall succeeds and the deploy step runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)