### PR TITLE
chore: rename worker ncrmro-website-astro → ncrmro-website

### DIFF
--- a/.github/actions/cloudflare-deploy/action.yml
+++ b/.github/actions/cloudflare-deploy/action.yml
@@ -20,7 +20,7 @@ inputs:
     required: false
     default: 'false'
   preview-alias:
-    description: 'DNS-safe alias for the preview URL (mode=upload only). When set, the preview URL becomes <alias>-ncrmro-website-astro.<acct>.workers.dev instead of <version-id>-…. Sanitize before passing — only [a-z0-9-] survives in DNS.'
+    description: 'DNS-safe alias for the preview URL (mode=upload only). When set, the preview URL becomes <alias>-ncrmro-website.<acct>.workers.dev instead of <version-id>-…. Sanitize before passing — only [a-z0-9-] survives in DNS.'
     required: false
     default: ''
 
@@ -83,7 +83,7 @@ runs:
 
     # `wrangler versions upload` creates a versioned preview without
     # touching the production alias. `--preview-alias` gives it a
-    # DNS-safe URL like <alias>-ncrmro-website-astro.<acct>.workers.dev
+    # DNS-safe URL like <alias>-ncrmro-website.<acct>.workers.dev
     # instead of the opaque <version-id>-… form.
     - name: Upload versioned preview
       id: upload
@@ -114,7 +114,7 @@ runs:
           url="$(grep -oE 'Version Preview URL: https://[^ ]+' "$log_file" | head -1 | sed 's/^Version Preview URL: //')"
         fi
         if [ -z "$url" ]; then
-          url="$(grep -oE 'https://[a-z0-9-]+-ncrmro-website-astro\.[a-z0-9]+\.workers\.dev' "$log_file" | head -1)"
+          url="$(grep -oE 'https://[a-z0-9-]+-ncrmro-website\.[a-z0-9]+\.workers\.dev' "$log_file" | head -1)"
         fi
         if [ -n "$url" ]; then
           echo "preview_url=$url" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v4
 
       # Derive a DNS-safe slug from the PR's source branch so the preview
-      # URL becomes <slug>-ncrmro-website-astro.<acct>.workers.dev instead
+      # URL becomes <slug>-ncrmro-website.<acct>.workers.dev instead
       # of the opaque <version-id>-… form. Lowercase, only [a-z0-9-],
       # collapsed dashes, trimmed leading/trailing dashes, capped at 45
       # chars to fit in the workers.dev subdomain label limit (63 chars

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,9 +61,9 @@ secrets.
 - `.github/actions/cloudflare-deploy/action.yml` — composite action
   shared by deploy and preview.
 
-Worker name: `ncrmro-website-astro` (per `wrangler.jsonc`). The preview
+Worker name: `ncrmro-website` (per `wrangler.jsonc`). The preview
 alias URL pattern is
-`<branch-slug>-ncrmro-website-astro.<acct>.workers.dev`.
+`<branch-slug>-ncrmro-website.<acct>.workers.dev`.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ as the env secrets are populated.
   `.github/workflows/preview.yml` publishes a versioned Cloudflare alias
   per PR and comments the URL; `.github/workflows/validate.yml` runs a
   fork-safe `astro build` on every PR.
-- **Worker**: `ncrmro-website-astro` (see `wrangler.jsonc`).
-- **Live**: https://ncrmro-website-astro.ncrmro.workers.dev/
+- **Worker**: `ncrmro-website` (see `wrangler.jsonc`).
+- **Live**: https://ncrmro-website.ncrmro.workers.dev/
 
 Required repo configuration:
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,6 +1,6 @@
 {
 	"$schema": "node_modules/wrangler/config-schema.json",
-	"name": "ncrmro-website-astro",
+	"name": "ncrmro-website",
 	"main": "@astrojs/cloudflare/entrypoints/server",
 	"compatibility_date": "2026-05-13",
 	"compatibility_flags": [


### PR DESCRIPTION
## Summary

The astro stack has fully replaced the Next.js stack on the production domain. This PR reclaims the canonical worker name `ncrmro-website` in source.

**Cloudflare-side changes already applied** (production):
- Deployed astro code under the new name, overwriting the dormant old `ncrmro-website` worker in place. Current version: `6feaec24-6f1f-4944-a0c7-9742d74955fb`.
- Moved `ncrmro.com` custom domain to the renamed worker via atomic flip (`PUT /workers/domains?override_existing_origin=true`).
- Deleted the orphaned `ncrmro-website-astro` worker.

**Source changes in this PR**:
- `wrangler.jsonc` — `name` field updated.
- `CLAUDE.md`, `README.md` — worker name and workers.dev URL references.
- `.github/actions/cloudflare-deploy/action.yml` — preview URL fallback regex + comments.
- `.github/workflows/preview.yml` — preview alias URL comment.

## Test plan

- [x] `bunx wrangler deploy` succeeded under the new name (`ncrmro-website` worker now serves Astro).
- [x] `ncrmro.com` still returns Astro (`<meta name="generator" content="Astro v6.3.1">`, 37 posts) throughout the rename.
- [x] `ncrmro-website-astro.ncrmro.workers.dev` now returns 404 (worker deleted).
- [ ] CI on this PR: `Validate` passes, `Preview` publishes versioned alias under `<branch-slug>-ncrmro-website.<acct>.workers.dev`.

## Stacked on #84

Independent of #84 (deploy.yml migration tolerance fix) — order of merge doesn't matter, but #84 first means the next post-merge Deploy is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)