### PR TITLE
feat(content): publish ai-outfitter posts

### DIFF
--- a/code/web/src/content/blog/announcing-ai-outfitter-outfitter-and-actions.mdx
+++ b/code/web/src/content/blog/announcing-ai-outfitter-outfitter-and-actions.mdx
@@ -1,0 +1,109 @@
+---
+title: Announcing ai-outfitter/outfitter and ai-outfitter/actions
+description: Reusable agent profiles locally, and the same profiles running headlessly from GitHub Actions.
+publish_date: 2026-07-09
+published: true
+tags: []
+---
+
+# Announcing ai-outfitter/outfitter and ai-outfitter/actions
+
+I have been poking at a simple question: what is the smallest useful packaging layer for agentic workflows?
+
+Not a whole platform. Not a dashboard. Not another giant orchestration story.
+
+Just enough structure to say: "run this kind of agent, with this profile, in this repo, for this unit of work."
+
+That is the shape behind two projects:
+
+- [`ai-outfitter/outfitter`](https://github.com/ai-outfitter/outfitter)
+- [`ai-outfitter/actions`](https://github.com/ai-outfitter/actions)
+
+## Outfitter
+
+Outfitter is a CLI for assembling and launching repeatable agent profiles.
+
+A profile can bundle the stuff that makes an agent useful in a particular role:
+
+- context
+- prompts
+- skills
+- extensions
+- subagents
+- agent-specific configuration
+
+The first target is [`pi`](https://github.com/earendil-works/pi-coding-agent), with Claude Code support in the same adapter-shaped model.
+
+The point is not to hide the agent CLI. The point is to make the setup reproducible.
+
+If an engineering profile should use a certain model, append a repo architecture note to the system prompt, expose a few skills, and launch with stricter controls, that should be something you can package, share, sync, and run again.
+
+```bash
+npx @ai-outfitter/outfitter
+```
+
+or:
+
+```bash
+npm install -g @ai-outfitter/outfitter
+outfitter run --profile engineer
+```
+
+Profiles can live locally, in a repo, or in a shared catalog. That makes them useful for personal defaults, team roles, and organization-approved agent setups.
+
+## Actions
+
+`ai-outfitter/actions` takes the same idea into GitHub Actions.
+
+It installs Outfitter on the runner, points it at a profile source, and runs the selected profile in headless print mode for one workflow run:
+
+```yaml
+- uses: ai-outfitter/actions@v1
+  with:
+    profile: reviewer
+    profile-source: my-org/outfitter-catalog
+    profile-source-ref: v1.2.0
+    prompt: >-
+      Review pull request #${{ github.event.pull_request.number }} in
+      ${{ github.repository }}. Use gh to read the diff, then post findings.
+  env:
+    ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+That gives you a small building block for workflows like:
+
+- review a PR when it leaves draft
+- audit sensitive paths on push
+- summarize commits on a schedule
+- complete a task when an issue is assigned to a bot account
+- smoke-test a deployment URL
+- open a triage issue when a deployment fails
+
+The action is deliberately thin. GitHub owns the trigger, token, checkout, and permissions. Outfitter owns profile assembly. The agent owns the work.
+
+## Why This Shape
+
+The thing I want is boring composability.
+
+Agent workflows should not require copy-pasting a bunch of prompt and CLI setup into every repo. They also should not require turning every automation into its own bespoke agent identity.
+
+With Outfitter, the reusable part becomes a profile. With Actions, the workflow part becomes a normal GitHub job. The handoff is just a prompt plus whatever structured context the workflow passes in.
+
+That means you can start small:
+
+1. Create one useful profile.
+2. Run it locally.
+3. Put it in a catalog when it starts being reused.
+4. Call it from GitHub Actions when the work should happen on a trigger.
+
+The security model stays understandable too. The GitHub token is the blast radius. Use the default `GITHUB_TOKEN` when possible, set explicit `permissions:`, pin profile sources you do not own, and do not paste untrusted issue bodies or PR titles directly into workflow prompts.
+
+## The Bet
+
+My bet is that agentic engineering workflows need a package manager feeling more than they need a command center feeling.
+
+Profiles should be portable. Skills should be reusable. GitHub Actions should be able to run a profile without every repo relearning the same setup ceremony.
+
+That is what `ai-outfitter/outfitter` and `ai-outfitter/actions` are trying to make boring.
+
+Local agent profiles. Shared catalogs. Headless CI runs. Same shape.

--- a/code/web/src/content/blog/few-profiles-many-skills.mdx
+++ b/code/web/src/content/blog/few-profiles-many-skills.mdx
@@ -1,0 +1,113 @@
+---
+title: Few Profiles, Many Skills
+description: A small pattern for adding agentic GitHub workflows without profile sprawl or near-duplicate Actions jobs.
+publish_date: 2026-07-09
+published: true
+tags: []
+---
+
+# Few Profiles, Many Skills
+
+The tempting way to build agentic GitHub workflows is to make every automation its own agent profile.
+
+One profile for idea triage. One for weekly KPI reports. One for deployment smoke tests. One for release review. One for failed deploys. One for retrospectives.
+
+It feels clean for the first few workflows because everything is explicit. Then the profiles start duplicating each other. They share the same repo rules, write policy, prompt-injection posture, escalation behavior, and GitHub conventions. The thing that actually changes is usually much smaller: the trigger facts.
+
+The pattern I keep coming back to is:
+
+**Few profiles. Many skills. Structured trigger context in the prompt.**
+
+Profiles should define identity, policy, and common operating rules. Skills should define workflow-specific behavior. GitHub Actions should pass exact event data into the prompt so the agent can decide which skill applies to this run.
+
+That keeps the system from turning into a taxonomy of near-identical agents.
+
+## The Job of the Action
+
+The GitHub Action should be boring. Its job is to expose facts:
+
+```json
+{
+  "trigger_context": {
+    "repository": "owner/repo",
+    "workflow": "agentic-workflows",
+    "run_id": "123456789",
+    "event_name": "issues",
+    "event_action": "labeled",
+    "issue_number": 42,
+    "issue_label": "idea",
+    "ref_name": "main",
+    "sha": "abc123"
+  }
+}
+```
+
+For a scheduled report, the same shape might include `schedule` and `report_period`. For a deployment, it might include `deployment_status`, `environment`, and `environment_url`. For a release, it might include `release_tag`.
+
+The action does not need to become an agent router. It does not need a new job body for every workflow. It passes the normalized trigger context and lets the profile interpret it.
+
+## The Job of the Profile
+
+The profile should be stable.
+
+It says things like:
+
+- how to treat untrusted content
+- when to commit directly vs. open a PR
+- how to cite evidence
+- which repo conventions matter
+- which permissions are allowed
+- how to escalate when the task is risky
+
+Those rules should not be copied into ten profiles just because ten triggers exist.
+
+The profile can then map structured trigger context to skills:
+
+- If an issue is labeled `idea`, load the idea-triage skill.
+- If the weekly schedule fires, load the KPI-report skill.
+- If a deployment succeeds and has an environment URL, load the smoke-test skill.
+- If a deployment fails, load the failed-deployment-triage skill.
+- If it is Friday afternoon, load the retrospective skill.
+
+Same agent posture. Different run facts. Different skill.
+
+## Why Skills Make This Work
+
+The important part is progressive disclosure.
+
+A skill lets the agent load the relevant behavior only when the trigger context calls for it. The idea-triage instructions do not have to sit in the profile next to the deployment-smoke-test instructions, the KPI-report instructions, the release-review instructions, and every future workflow path you have not invented yet.
+
+That matters because stuffing every possible workflow into the profile or system prompt makes the agent worse. The prompt gets longer, the decision surface gets blurrier, and unrelated instructions start competing for attention.
+
+Skills keep the profile small while letting the capability surface grow. The agent begins with stable policy and a compact context block. Then, when the context says "this is an issue labeled idea," it loads the idea-triage behavior. When the context says "this is a successful deployment," it loads the smoke-test behavior.
+
+That is a much cleaner scaling story than building one giant profile that tries to remember every possible path up front.
+
+## The DRY Line
+
+Most new workflows are not new agent identities. They are the same agent seeing different facts.
+
+So adding a workflow should usually mean:
+
+1. Add or reuse a skill.
+2. Add the trigger that supplies the right structured context.
+3. Keep the profile stable unless the policy actually changed.
+
+Permissions can still vary by workflow because GitHub permissions are a real security boundary. A deployment triage job may need different permissions than a read-only report. But the agent profile does not need to multiply just because the trigger changed.
+
+The result is a nice division of labor:
+
+- GitHub Actions: trigger plumbing, permissions, secrets, exact event data
+- Profiles: identity, shared policy, common operating rules
+- Skills: workflow-specific behavior, loaded only when relevant
+- Prompt payload: the structured handoff between the action and the agent
+
+## The Short Version
+
+Do not make every automation its own profile.
+
+Keep profiles few and stable. Let skills multiply. Pass structured data from the GitHub Action into the prompt so the agent can activate the right skill for the run.
+
+That gives you a system where new agentic workflows are additive. You can add idea triage, reports, smoke tests, release reviews, and retrospectives without creating an explosion of profiles or copying the same GitHub Actions job over and over.
+
+Few profiles. Many skills. Structured trigger context.


### PR DESCRIPTION
## What changed

- Adds a short design-pattern post: "Few Profiles, Many Skills."
- Adds an announcement post for `ai-outfitter/outfitter` and `ai-outfitter/actions`.

## Why

Publishes the agentic workflow pattern from the source report: keep profiles stable, grow skills, and pass structured GitHub Actions trigger context into the prompt so new workflows do not require profile or job sprawl.

## Validation

- `pnpm run build`
